### PR TITLE
Expose Suite and MetricsChecker at top-level

### DIFF
--- a/hdat/__init__.py
+++ b/hdat/__init__.py
@@ -1,0 +1,1 @@
+from .suite import Suite, MetricsChecker # noqa


### PR DESCRIPTION
This allows 'from hdat import Suite, MetricsChecker'. noqa is for flake8 warning about unused imports. Closes #19 