### PR TITLE
Add capability to process multiple specs for various arguments

### DIFF
--- a/hdat/hdat_cli.py
+++ b/hdat/hdat_cli.py
@@ -22,8 +22,8 @@ def parse_arguments(arguments):
 
     show_help = 'visualize a single result'
     show_parser = subparsers.add_parser('show', help=show_help)
-    show_case_help = 'case specifier to show results'
-    show_parser.add_argument('casespecs', nargs='*', default='', metavar='<case>', help=show_case_help)
+    show_result_help = 'result specifier to show'
+    show_parser.add_argument('resultspec', nargs='*', default='', metavar='<result>', help=show_result_help)
 
     runshow_help = 'run then visualize a single result'
     runshow_parser = subparsers.add_parser('runshow', help=runshow_help)

--- a/hdat/hdat_cli.py
+++ b/hdat/hdat_cli.py
@@ -69,8 +69,9 @@ def hdat_cli(arguments, suites, golden_store, archive, git_info):
     elif args.command == 'show':
         if args.casespecs:
             cases = resolve_casespecs(suites, args.casespecs)
-            for casespec in args.casespecs:
-                results = resolve_resultspecs(archive, casespec)
+            for suite_id, case_id in cases:
+                case = "".join(['{}/{}'.format(suite_id, case_id)])
+                results = resolve_resultspecs(archive, case)
                 for result in results:
                     show_result(suites, result)
         else:

--- a/hdat/hdat_cli.py
+++ b/hdat/hdat_cli.py
@@ -67,15 +67,8 @@ def hdat_cli(arguments, suites, golden_store, archive, git_info):
         if cases_status['pass'] < len(cases):
             raise AbortError(_format_cases_status(cases_status))
     elif args.command == 'show':
-        if args.casespecs:
-            cases = resolve_casespecs(suites, args.casespecs)
-            for suite_id, case_id in cases:
-                case = "".join(['{}/{}'.format(suite_id, case_id)])
-                results = resolve_resultspecs(archive, case)
-                for result in results:
-                    show_result(suites, result)
-        else:
-            results = resolve_resultspecs(archive, args.casespecs)
+        for resultspec in args.resultspec:
+            results = resolve_resultspecs(archive, resultspec)
             for result in results:
                 show_result(suites, result)
     elif args.command == 'runshow':

--- a/hdat/hdat_cli.py
+++ b/hdat/hdat_cli.py
@@ -17,16 +17,18 @@ def parse_arguments(arguments):
 
     run_help = 'run cases, store results in archive, compare against goldens'
     run_parser = subparsers.add_parser('run', help=run_help)
-    run_parser.add_argument('casespecs', nargs='*', default=[''], metavar='<case>')
+    run_case_help = 'case specifier to run'
+    run_parser.add_argument('casespecs', nargs='*', default=[''], metavar='<case>', help=run_case_help)
 
     show_help = 'visualize a single result'
     show_parser = subparsers.add_parser('show', help=show_help)
-    show_result_help = 'result specifier to show'
-    show_parser.add_argument('casespecs', nargs='*', default='', metavar='<result>', help=show_result_help)
+    show_case_help = 'case specifier to show results'
+    show_parser.add_argument('casespecs', nargs='*', default='', metavar='<case>', help=show_case_help)
 
     runshow_help = 'run then visualize a single result'
     runshow_parser = subparsers.add_parser('runshow', help=runshow_help)
-    runshow_parser.add_argument('casespecs', nargs='*', default='', metavar='<result>')
+    runshow_case_help = 'case specifier to run and show results'
+    runshow_parser.add_argument('casespecs', nargs='*', default='', metavar='<case>', help=runshow_case_help)
 
     diff_help = 'compare two results'
     diff_parser = subparsers.add_parser('diff', help=diff_help)

--- a/hdat/hdat_cli.py
+++ b/hdat/hdat_cli.py
@@ -22,11 +22,11 @@ def parse_arguments(arguments):
     show_help = 'visualize a single result'
     show_parser = subparsers.add_parser('show', help=show_help)
     show_result_help = 'result specifier to show'
-    show_parser.add_argument('resultspec', nargs="?", default='', metavar='<result>', help=show_result_help)
+    show_parser.add_argument('casespecs', nargs='*', default='', metavar='<result>', help=show_result_help)
 
     runshow_help = 'run then visualize a single result'
     runshow_parser = subparsers.add_parser('runshow', help=runshow_help)
-    runshow_parser.add_argument('casespecs', nargs=1, default='', metavar='<result>')
+    runshow_parser.add_argument('casespecs', nargs='*', default='', metavar='<result>')
 
     diff_help = 'compare two results'
     diff_parser = subparsers.add_parser('diff', help=diff_help)
@@ -65,9 +65,16 @@ def hdat_cli(arguments, suites, golden_store, archive, git_info):
         if cases_status['pass'] < len(cases):
             raise AbortError(_format_cases_status(cases_status))
     elif args.command == 'show':
-        results = resolve_resultspecs(archive, args.resultspec)
-        for result in results:
-            show_result(suites, result)
+        if args.casespecs:
+            cases = resolve_casespecs(suites, args.casespecs)
+            for casespec in args.casespecs:
+                results = resolve_resultspecs(archive, casespec)
+                for result in results:
+                    show_result(suites, result)
+        else:
+            results = resolve_resultspecs(archive, args.casespecs)
+            for result in results:
+                show_result(suites, result)
     elif args.command == 'runshow':
         cases = resolve_casespecs(suites, args.casespecs)
         cases_status = run_cases(suites, golden_store, archive, git_info, cases)

--- a/tests/test_suite_hdat.py
+++ b/tests/test_suite_hdat.py
@@ -14,9 +14,7 @@ class BaseSuite(Suite):
         return OrderedDict()
 
     def show(self, result):
-        raise NotImplementedError('showing "{}"'.format(
-            print_resultspec(result)
-        ))
+        print('Success in showing {}'.format(print_resultspec(result)))
 
     def diff(self, golden_result, result):
         raise NotImplementedError('diffing "{}" and "{}"'.format(

--- a/tests/test_suite_hdat.py
+++ b/tests/test_suite_hdat.py
@@ -14,7 +14,9 @@ class BaseSuite(Suite):
         return OrderedDict()
 
     def show(self, result):
-        print('Success in showing {}'.format(print_resultspec(result)))
+        raise NotImplementedError('showing "{}"'.format(
+            print_resultspec(result)
+        ))
 
     def diff(self, golden_result, result):
         raise NotImplementedError('diffing "{}" and "{}"'.format(


### PR DESCRIPTION
Addressing #27 

Done:
- Added multi-spec capability to `show` and `runshow`
- Refined help text to improve clarity.