### PR TITLE
Redesign csv subcommand handling

### DIFF
--- a/hdat/csv.py
+++ b/hdat/csv.py
@@ -1,0 +1,49 @@
+from collections import defaultdict
+from itertools import chain
+
+
+def expand_key_specifier(result, nested_key):
+    if nested_key[-1] == "*":
+        nested_data = get_nested_item(result, nested_key[:-1])
+        if isinstance(nested_data, dict):
+            for key in nested_data:
+                yield nested_key[:-1] + [key]
+    else:
+        yield nested_key
+
+
+def get_nested_item(result, nested_key):
+    num_levels = len(nested_key)
+    if nested_key[0] not in result:
+        return ''
+    elif num_levels == 0:
+        return
+    elif num_levels == 1:
+        return result[nested_key[0]]
+    else:
+        return get_nested_item(result[nested_key[0]], nested_key[1:])
+
+
+def print_results(results, input_keys_str):
+    if not input_keys_str:
+        input_keys_str = 'case_id,result_id,ran_on,commit,metrics.*'
+    input_keys = [key.strip() for key in input_keys_str.split(",")]
+    key_specifiers = [key.split(".") for key in input_keys]
+
+    keys = set()
+    all_data = []
+    for result in results:
+        result_data = defaultdict(lambda: '')
+        expanded_keys_generator = [expand_key_specifier(result, ks) for ks in key_specifiers]
+        expanded_keys = chain.from_iterable(expanded_keys_generator)
+        for expanded_key in expanded_keys:
+            result_key = '.'.join(expanded_key)
+            keys.add(result_key)
+            result_data[result_key] = get_nested_item(result, expanded_key)
+        all_data.append(result_data)
+
+    sorted_keys = sorted(list(keys))
+    print(", ".join(sorted_keys))
+    for result_data in all_data:
+        data_out = [str(result_data[key]) for key in sorted_keys]
+        print(", ".join(data_out))

--- a/hdat/hdat_cli.py
+++ b/hdat/hdat_cli.py
@@ -3,7 +3,7 @@ import traceback
 
 from .resultspec import resolve_resultspecs, print_resultspec
 from .casespec import resolve_casespecs, select_suite
-from .csv import print_results
+from .reports import print_results
 from .runner import run_cases
 from .util import AbortError
 

--- a/hdat/hdat_cli.py
+++ b/hdat/hdat_cli.py
@@ -1,13 +1,11 @@
 import argparse
 import traceback
-import sys
 
 from .resultspec import resolve_resultspecs, print_resultspec
 from .casespec import resolve_casespecs, select_suite
 from .runner import run_cases
 from .util import AbortError
 from collections import defaultdict
-from functools import reduce
 
 
 def parse_arguments(arguments):

--- a/hdat/reports.py
+++ b/hdat/reports.py
@@ -17,12 +17,17 @@ def expand_key_parts(result, nested_key):
 
 def get_nested_item(result, nested_key):
     num_levels = len(nested_key)
-    if num_levels == 0 or nested_key[0] not in result:
+    try:
+        if num_levels == 0 or nested_key[0] not in result:
+            return
+        elif num_levels == 1:
+            return result[nested_key[0]]
+        else:
+            return get_nested_item(result[nested_key[0]], nested_key[1:])
+    except TypeError:
+        error_msg = 'Result value "{}" is not iterable and has no specifier "{}"\n'
+        sys.stderr.write(error_msg.format(result, nested_key[0]))
         return
-    elif num_levels == 1:
-        return result[nested_key[0]]
-    else:
-        return get_nested_item(result[nested_key[0]], nested_key[1:])
 
 
 def print_results(results, input_keys_str):

--- a/hdat/reports.py
+++ b/hdat/reports.py
@@ -25,8 +25,6 @@ def get_nested_item(result, nested_key):
         else:
             return get_nested_item(result[nested_key[0]], nested_key[1:])
     except TypeError:
-        error_msg = 'Result value "{}" is not iterable and has no specifier "{}"\n'
-        sys.stderr.write(error_msg.format(result, nested_key[0]))
         return
 
 
@@ -38,20 +36,20 @@ def print_results(results, input_keys_str):
     key_parts = [key.split('.') for key in input_keys]
 
     keys = set()
-    all_data = []
+    all_result_data = []
     for result in results:
         result_data = defaultdict(lambda: '')
-        expanded_keys_gen = [expand_key_parts(result, ks) for ks in key_parts]
-        expanded_keys = chain.from_iterable(expanded_keys_gen)
+        expanded_keys_gens = [expand_key_parts(result, ks) for ks in key_parts]
+        expanded_keys = chain.from_iterable(expanded_keys_gens)
         for expanded_key in expanded_keys:
             result_key = '.'.join(expanded_key)
             keys.add(result_key)
             result_data[result_key] = get_nested_item(result, expanded_key)
-        all_data.append(result_data)
+        all_result_data.append(result_data)
 
     output_writer = csv.writer(sys.stdout)
     sorted_keys = sorted(list(keys))
     output_writer.writerow(sorted_keys)
-    for result_data in all_data:
+    for result_data in all_result_data:
         data_out = [result_data[key] for key in sorted_keys]
         output_writer.writerow(data_out)

--- a/tests/csv_test.py
+++ b/tests/csv_test.py
@@ -114,9 +114,6 @@ class TestUnusedKeys:
 
 
 class TestGetResults:
-    def test_no_data(self, mock_results):
-        assert not hdat.get_result_data('undefined_key', mock_results[0])
-
     def test_matched_data(self, mock_results):
         assert hdat.get_result_data('case_id', mock_results[0]) == '1'
 

--- a/tests/csv_test.py
+++ b/tests/csv_test.py
@@ -84,34 +84,6 @@ class TestGetKeys:
         ]
 
 
-class TestUnusedKeys:
-    def test_no_unused(self, mock_keys):
-        distinct_keys = mock_keys
-
-        assert not hdat.get_unused_keys(mock_keys, distinct_keys)
-
-    def test_some_unused(self, mock_keys):
-        distinct_keys = ['case_id', 'result_id', 'commit']
-
-        assert 'ran_on' in hdat.get_unused_keys(mock_keys, distinct_keys)
-        assert 'metrics.*' in hdat.get_unused_keys(mock_keys, distinct_keys)
-
-    def test_more_distinct(self, mock_keys):
-        mock_keys = ['case_id', 'result_id', 'commit']
-
-        assert not hdat.get_unused_keys(mock_keys, mock_keys)
-
-    def test_non_dict_wildcard(self, mock_keys):
-        distinct_keys = ['case_id', 'result_id', 'commit', 'ran_on', 'metrics']
-
-        assert 'metrics.*' in hdat.get_unused_keys(mock_keys, distinct_keys)
-
-    def test_non_wildcard(self):
-        mock_keys = ['case_id', 'result_id', 'metrics']
-        distinct_keys = ['case_id', 'result_id', 'metrics.mean', 'metrics.std']
-
-        assert 'metrics' in hdat.get_unused_keys(mock_keys, distinct_keys)
-
 
 class TestGetResults:
     def test_matched_data(self, mock_results):
@@ -143,10 +115,8 @@ class TestPrintResult:
         hdat.print_results([mock_results[0]], None)
         out, err = capfd.readouterr()
         assert out == 'case_id, ran_on, result_id\n1, 100, r1\n'
-        assert 'commit' in err and 'metrics.*' in err
 
     def test_all_matching_inputs(self, mock_results, capfd):
         hdat.print_results([mock_results[0]], 'suite_id,case_id,result_id,ran_on')
         out, err = capfd.readouterr()
         assert out == 'case_id, ran_on, result_id, suite_id\n1, 100, r1, a\n'
-        assert not err

--- a/tests/csv_test.py
+++ b/tests/csv_test.py
@@ -35,10 +35,20 @@ class TestPrintResult:
     def test_print_default(self, mock_nested_result, capfd):
         hdat.print_results([mock_nested_result], '')
         out, err = capfd.readouterr()
-        assert 'case_id, commit, metrics.max, metrics.mean' in out
-        assert 'cid, c1, 100, 50, 1, 100, 3, 123.456, r1\n' in out
+        assert 'case_id,commit,metrics.max,metrics.mean' in out
+        assert 'cid,c1,100,50,1,100,3,123.456,r1' in out
 
     def test_non_existing_keys(self, mock_nested_result, capfd):
         hdat.print_results([mock_nested_result], 'case_id, wrong.nestedkey, wrongkey')
         out, err = capfd.readouterr()
-        assert out == 'case_id, wrong.nestedkey, wrongkey\ncid, , \n'
+        assert 'case_id,wrong.nestedkey,wrongkey' in out
+
+    def test_quoted_key(self, mock_nested_result, capfd):
+        hdat.print_results([mock_nested_result], 'case_id, "quotedkey"')
+        out, err = capfd.readouterr()
+        assert '"""quotedkey""",case_id' in out
+
+    def test_space_in_key(self, mock_nested_result, capfd):
+        hdat.print_results([mock_nested_result], 'case_id, space key, commit')
+        out, err = capfd.readouterr()
+        assert 'case_id,commit,space key' in out

--- a/tests/csv_test.py
+++ b/tests/csv_test.py
@@ -1,121 +1,44 @@
+import pytest
+
+import hdat.csv as csv
 import hdat.hdat_cli as hdat
 
 
-class TestGetKeys:
-
-    def test_keys_default(self, mock_results, mock_keys):
-        assert hdat.get_result_keys(mock_results[0], mock_keys) == (
-            ['case_id', 'ran_on', 'result_id']
-        )
-
-    def test_non_existing_keys(self, mock_results):
-        in_keys = ['case_id', 'result_id', 'metrics.mean', 'metrics.std']
-
-        assert hdat.get_result_keys(mock_results[0], in_keys) == (
-            ['case_id', 'result_id']
-        )
-
-    def test_with_wildcard(self):
-        mock_result = {
-            "case_id": "cid",
-            "commit": "c1",
-            "metrics": {
-                "max": 100,
-                "mean": 50,
-                "min": 1,
-                "size": 100,
-                "std": 3
-            },
-            "ran_on": 123.456,
-            "result_id": "r1",
-            "status": "pass",
-            "suite_id": "mock_suite"
-        }
-        in_keys = ['case_id', 'result_id', 'ran_on', 'status', 'metrics.*']
-
-        assert hdat.get_result_keys(mock_result, in_keys) == [
-            'case_id', 'metrics.max', 'metrics.mean',
-            'metrics.min', 'metrics.size', 'metrics.std',
-            'ran_on', 'result_id', 'status'
-        ]
-
-    def test_nested_keys(self):
-        mock_result = {
-            "case_id": "cid",
-            "commit": "c1",
-            "metrics": {
-                "max": 100,
-                "mean": 50,
-                "min": 1,
-                "size": 100,
-                "std": 3
-            },
-            "ran_on": 123.456,
-            "result_id": "r1",
-            "status": "pass",
-            "suite_id": "mock_suite"
-        }
-        in_keys = ['case_id', 'metrics.max', 'metrics.mean', 'metrics.size']
-
-        assert hdat.get_result_keys(mock_result, in_keys) == [
-            'case_id', 'metrics.max', 'metrics.mean', 'metrics.size'
-        ]
-
-    def test_dot_modifier(self):
-        mock_result = {
-            "case_id": "cid",
-            "commit": "c1",
-            "metrics": {
-                "max": 100,
-                "mean": 50,
-                "min": 1,
-                "size": 100,
-                "std": 3
-            },
-            "ran_on": 123.456,
-            "result_id": "r1",
-            "status": "pass",
-            "suite_id": "mock_suite"
-        }
-        in_keys = ['case_id', 'result_id', 'commit', 'metrics.']
-
-        assert hdat.get_result_keys(mock_result, in_keys) == [
-            'case_id', 'commit', 'result_id'
-        ]
+@pytest.fixture
+def mock_nested_result():
+    return {
+        "case_id": "cid",
+        "commit": "c1",
+        "metrics": {
+            "max": 100,
+            "mean": 50,
+            "min": 1,
+            "size": 100,
+            "std": 3
+        },
+        "ran_on": 123.456,
+        "result_id": "r1",
+        "status": "pass",
+        "suite_id": "mock_suite"
+    }
 
 
-class TestGetResults:
-    def test_matched_data(self, mock_results):
-        assert hdat.get_result_data('case_id', mock_results[0]) == '1'
+class TestNestedItems:
+    def test_non_nested_key(self, mock_nested_result):
+        assert csv.get_nested_item(mock_nested_result, ['case_id']) == 'cid'
 
-    def test_nested_data(self):
-        mock_result = {
-            "case_id": "cid",
-            "commit": "c1",
-            "metrics": {
-                "max": 100,
-                "mean": 50,
-                "min": 1,
-                "size": 100,
-                "std": 3
-            },
-            "ran_on": 123.456,
-            "result_id": "r1",
-            "status": "pass",
-            "suite_id": "mock_suite"
-        }
-
-        assert hdat.get_result_data('metrics.max', mock_result) == '100'
-        assert not hdat.get_result_data('metrics.', mock_result)
+    def test_nested_key(self, mock_nested_result):
+        assert csv.get_nested_item(mock_nested_result, ['metrics', 'max']) == 100
 
 
 class TestPrintResult:
-    def test_print_default(self, mock_results, capfd):
-        hdat.print_results([mock_results[0]], None)
+    def test_print_default(self, mock_nested_result, capfd):
+        hdat.print_results([mock_nested_result], '')
         out, err = capfd.readouterr()
-        assert out == 'case_id, ran_on, result_id\n1, 100, r1\n'
+        assert 'case_id, commit, metrics.max, metrics.mean' in out
+        assert 'cid, c1, 100, 50, 1, 100, 3, 123.456, r1\n' in out
 
-    def test_all_matching_inputs(self, mock_results, capfd):
-        hdat.print_results([mock_results[0]], 'suite_id,case_id,result_id,ran_on')
+    def test_non_existing_keys(self, mock_nested_result, capfd):
+        hdat.print_results([mock_nested_result], 'case_id, wrong.nestedkey, wrongkey')
         out, err = capfd.readouterr()
-        assert out == 'case_id, ran_on, result_id, suite_id\n1, 100, r1, a\n'
+        assert out == 'case_id, wrong.nestedkey, wrongkey\ncid, , \n'

--- a/tests/csv_test.py
+++ b/tests/csv_test.py
@@ -84,7 +84,6 @@ class TestGetKeys:
         ]
 
 
-
 class TestGetResults:
     def test_matched_data(self, mock_results):
         assert hdat.get_result_data('case_id', mock_results[0]) == '1'

--- a/tests/csv_test.py
+++ b/tests/csv_test.py
@@ -1,11 +1,11 @@
 import pytest
 
-import hdat.csv as csv
+import hdat.reports as reports
 import hdat.hdat_cli as hdat
 
 
 @pytest.fixture
-def mock_nested_result():
+def nested_result():
     return {
         "case_id": "cid",
         "commit": "c1",
@@ -24,31 +24,47 @@ def mock_nested_result():
 
 
 class TestNestedItems:
-    def test_non_nested_key(self, mock_nested_result):
-        assert csv.get_nested_item(mock_nested_result, ['case_id']) == 'cid'
+    def test_non_nested_key(self, nested_result):
+        assert reports.get_nested_item(nested_result, ['case_id']) == 'cid'
 
-    def test_nested_key(self, mock_nested_result):
-        assert csv.get_nested_item(mock_nested_result, ['metrics', 'max']) == 100
+    def test_nested_key(self, nested_result):
+        assert reports.get_nested_item(nested_result, ['metrics', 'max']) == 100
+
+    def test_nested_key_not_in_result(self, mock_results):
+        assert reports.get_nested_item(mock_results[0], ['metrics', 'max']) is None
+
+    def test_nested_key_non_nested_result(self):
+        mock_non_nested_result = {
+            "case_id": "cid",
+            "commit": "c1",
+            "metrics": 10,
+            "ran_on": 123.456,
+            "result_id": "r1",
+            "status": "pass",
+            "suite_id": "mock_suite"
+        }
+
+        assert reports.get_nested_item(mock_non_nested_result, ['metrics', 'max']) is None
 
 
 class TestPrintResult:
-    def test_print_default(self, mock_nested_result, capfd):
-        hdat.print_results([mock_nested_result], '')
+    def test_print_default(self, nested_result, capfd):
+        hdat.print_results([nested_result], '')
         out, err = capfd.readouterr()
         assert 'case_id,commit,metrics.max,metrics.mean' in out
         assert 'cid,c1,100,50,1,100,3,123.456,r1' in out
 
-    def test_non_existing_keys(self, mock_nested_result, capfd):
-        hdat.print_results([mock_nested_result], 'case_id, wrong.nestedkey, wrongkey')
+    def test_non_existing_keys(self, nested_result, capfd):
+        hdat.print_results([nested_result], 'case_id, wrong.nestedkey, wrongkey')
         out, err = capfd.readouterr()
         assert 'case_id,wrong.nestedkey,wrongkey' in out
 
-    def test_quoted_key(self, mock_nested_result, capfd):
-        hdat.print_results([mock_nested_result], 'case_id, "quotedkey"')
+    def test_quoted_key(self, nested_result, capfd):
+        hdat.print_results([nested_result], 'case_id, "quotedkey"')
         out, err = capfd.readouterr()
         assert '"""quotedkey""",case_id' in out
 
-    def test_space_in_key(self, mock_nested_result, capfd):
-        hdat.print_results([mock_nested_result], 'case_id, space key, commit')
+    def test_space_in_key(self, nested_result, capfd):
+        hdat.print_results([nested_result], 'case_id, space key, commit')
         out, err = capfd.readouterr()
         assert 'case_id,commit,space key' in out


### PR DESCRIPTION
Addressing Issue #9 

Rewrite `print_results` to handle results using the generator to avoid dumping all the results and data into a list.