### PR TITLE
Add bash completion script

### DIFF
--- a/hdat/hdat_completion
+++ b/hdat/hdat_completion
@@ -1,0 +1,30 @@
+# To enable this bash completion, source this file:
+#
+# source /etc/bash_completion.d/hdat_completion
+# or
+# . /etc/bash_completion.d/hdat_completion
+#
+# To uninstall, remove the file from "bash_completion.d"
+
+_hdat()
+{
+  local cur prev commands
+
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev=${COMP_WORDS[COMP_CWORD-1]}
+  commands='csv diff list run runshow show verify'
+
+  case "$prev" in
+    hdat)
+      COMPREPLY=( $(compgen -W '$commands' -- $cur) )
+      return 0;;
+    run | show)
+      COMPREPLY=( $(compgen -W '$(hdat list)' -- $cur) )
+      return 0;;
+    runshow)
+      COMPREPLY=( $(compgen -W '$(hdat list | sed "s/\/.*//")' -- $cur) )
+      return 0;;
+  esac
+}
+
+complete -o nospace -F _hdat hdat

--- a/hdat/hdat_completion
+++ b/hdat/hdat_completion
@@ -1,8 +1,8 @@
 # To enable this bash completion, source this file:
 #
-# source /etc/bash_completion.d/hdat_completion
+# source ~/bash_completion.d/hdat_completion
 # or
-# . /etc/bash_completion.d/hdat_completion
+# . ~/bash_completion.d/hdat_completion
 #
 # To uninstall, remove the file from "bash_completion.d"
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     },
 
     package_data={},
-    data_files=[],
+    data_files=[('/etc/bash_completion.d/', ['hdat/hdat_completion'])],
     entry_points={
         'console_scripts': [
             'hdat = hdat.main:main'

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 from os import path
 
 here = path.abspath(path.dirname(__file__))
-completion_dir = '/'.join([path.expanduser('~'), 'bash_completion.d/'])
+completion_dir = path.join(path.expanduser('~'), 'bash_completion.d/')
 
 description = 'High Dimensional Algorithm Tester: A tool for manually verifying high-dimensionality algorithms.'
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup, find_packages
 from os import path
 
 here = path.abspath(path.dirname(__file__))
+completion_dir = '/'.join([path.expanduser('~'), 'bash_completion.d/'])
 
 description = 'High Dimensional Algorithm Tester: A tool for manually verifying high-dimensionality algorithms.'
 
@@ -46,7 +47,7 @@ setup(
     },
 
     package_data={},
-    data_files=[('/etc/bash_completion.d/', ['hdat/hdat_completion'])],
+    data_files=[(completion_dir, ['hdat/hdat_completion'])],
     entry_points={
         'console_scripts': [
             'hdat = hdat.main:main'


### PR DESCRIPTION
Addressing Issue #2 

Done:
- Add bash completion script to complete commands `list`, `run`, `show`, and `runshow`
- Add script to auto-install with `setuptools` in `setup.py`
- Dynamically pull suites and cases when completing commands requiring `casespec` or `resultspec`

To do:
- Enable script by sourcing it automatically during install if possible
- Dynamically pull commands instead of hard coding a list (optional)
- Test the script using `pytest` (optional)